### PR TITLE
enhance button hover states with color adjustments

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -127,6 +127,8 @@ a:hover {
 
 .btn-primary:hover:not(:disabled) {
   background-color: var(--color-primary-dark);
+  color: white;
+  text-decoration: none;
 }
 
 .btn-secondary {
@@ -136,6 +138,7 @@ a:hover {
 
 .btn-secondary:hover:not(:disabled) {
   background-color: var(--color-secondary-dark);
+  color: white;
 }
 
 .btn-outline {

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -35,6 +35,12 @@
 .header-actions {
   display: flex;
   gap: var(--spacing-sm);
+  align-items: center;
+}
+
+.header-actions .btn {
+  white-space: nowrap;
+  overflow: visible;
 }
 
 .dashboard-content {
@@ -98,9 +104,12 @@
 }
 
 .action-card:hover {
-  transform: translateY(-2px);
   box-shadow: var(--shadow-md);
-  color: var(--color-primary);
+}
+
+.action-card.btn:hover,
+.action-card .btn:hover {
+  color: white;
 }
 
 .action-icon {

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -76,6 +76,12 @@
 .hero-cta .btn {
   padding: var(--spacing-md) var(--spacing-xl);
   font-size: var(--font-size-lg);
+  white-space: nowrap;
+}
+
+.hero-cta .btn-primary:hover,
+.hero-cta .btn-secondary:hover {
+  color: white;
 }
 
 /* Responsive home page */

--- a/frontend/src/pages/Recipients.css
+++ b/frontend/src/pages/Recipients.css
@@ -192,6 +192,7 @@
 
 .btn-danger:hover:not(:disabled) {
   background-color: #dc2626;
+  color: white;
 }
 
 /* Responsive */


### PR DESCRIPTION
This pull request makes several improvements to button and card hover styles across the frontend, focusing on consistent appearance and better alignment. The main changes ensure that button text turns white on hover for better contrast, improve button layout in headers and hero sections, and refine card hover behavior.

**Button hover color consistency:**
- Updated `.btn-primary:hover:not(:disabled)`, `.btn-secondary:hover:not(:disabled)`, and `.btn-danger:hover:not(:disabled)` in `index.css` so that button text turns white on hover, and removed underlines for primary buttons, ensuring consistent and accessible contrast. [[1]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236R130-R131) [[2]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236R141) [[3]](diffhunk://#diff-ad17a748176dc6cc04b801932cffbd472d64865a21ce53dfa3155d60209c4d64R195)

**Button layout improvements:**
- In `Dashboard.css`, aligned header action buttons vertically and ensured button text does not wrap, improving the appearance of buttons in header areas.
- In `Home.css`, prevented hero section buttons from wrapping and ensured their text turns white on hover for both primary and secondary styles.

**Card hover behavior:**
- Adjusted `.action-card` hover styles in `Dashboard.css` to remove the vertical translation effect and ensure buttons within action cards turn white on hover, maintaining visual consistency with other buttons.